### PR TITLE
Add code interpreter prompts for Antwerp tariffs

### DIFF
--- a/2025_tariffs/Antwerp/Code_Interpreter/harbour_dues
+++ b/2025_tariffs/Antwerp/Code_Interpreter/harbour_dues
@@ -1,0 +1,291 @@
+Act as a code interpreter and execute the following code. Explain any discrepancy with the invoice amount.
+"""
+Antwerp Harbour Dues Calculator
+-------------------------------
+
+Two products are supported:
+  1) ZVR_GT – GT-based harbour dues
+  2) Aanlegrecht_Tons – cargo based dues on loaded/discharged tonnage
+
+The code below follows the rules from the prompt and validates ±2% against the
+invoice amount if provided.
+"""
+
+from __future__ import annotations
+import argparse
+import json
+import math
+from typing import Dict, Tuple
+
+# ---------------------------------------------------------------------------
+# Common helpers
+# ---------------------------------------------------------------------------
+
+TYPE_MAP = {
+    "tanker": "tanker",
+    "bulkcarrier": "bulk",
+    "container": "containership",
+    "roro": "roro",
+    "reefer": "reefer",
+}
+
+LINER_TARIFFS = {
+    "containership": {"deepsea": 0.3275, "shortsea": 0.2629},
+    "roro": {"deepsea": 0.2237, "shortsea": 0.2237},
+    "tanker": {"deepsea": 0.4752, "shortsea": 0.4752},
+    "reefer": {"deepsea": 0.3621, "shortsea": 0.3621},
+    "bulk": {"deepsea": 0.3621, "shortsea": 0.3621},
+    "other": {"deepsea": 0.5322, "shortsea": 0.5322},
+}
+
+NON_LINER_TARIFFS = {
+    "containership": 0.8072,
+    "roro": 0.6243,
+    "tanker": 0.9337,
+    "reefer": 0.7623,
+    "bulk": 0.7623,
+    "other": 0.9337,
+}
+
+
+def _map_type(raw: str) -> str:
+    return TYPE_MAP.get(raw.lower(), "other")
+
+
+def _service_type(is_shortsea: bool, is_liner: bool) -> str:
+    if is_shortsea:
+        return "shortsea"
+    if is_liner:
+        return "deepsea"
+    return "non-liner"
+
+
+def _frequency_discount(service_type: str, voyage_no: int | None) -> float:
+    if voyage_no is None:
+        return 0.0
+    if service_type == "deepsea":
+        if 53 <= voyage_no <= 150:
+            return 0.10
+        if 151 <= voyage_no <= 200:
+            return 0.20
+        if voyage_no >= 201:
+            return 0.30
+    if service_type == "shortsea":
+        if 27 <= voyage_no <= 52:
+            return 0.25
+        if voyage_no >= 53:
+            return 0.50
+    return 0.0
+
+
+def _esi_discount(score: float | None, built_year: int | None) -> float:
+    if score is None:
+        return 0.0
+    if 70.1 <= score <= 100:
+        return 0.15
+    if 50.1 <= score <= 70.09:
+        return 0.10
+    if 31.0 <= score <= 50.09 and (built_year is None or built_year <= 2010):
+        return 0.04
+    return 0.0
+
+
+def calculate_zvr_gt(
+    *,
+    vessel_type_raw: str,
+    gt: float,
+    voyage_number: int | None,
+    is_shortsea: bool,
+    is_liner: bool,
+    esi_score: float | None,
+    vessel_built_year: int | None,
+    special_rate: bool,
+    days_in_port: int,
+    invoice_amount: float | None,
+) -> Tuple[str, Dict]:
+    mapped_type = _map_type(vessel_type_raw)
+    service_type = _service_type(is_shortsea, is_liner)
+
+    if service_type == "non-liner":
+        base_tariff = NON_LINER_TARIFFS[mapped_type]
+    else:
+        base_tariff = LINER_TARIFFS[mapped_type][service_type]
+
+    base = gt * base_tariff
+    freq_disc = _frequency_discount(service_type, voyage_number)
+    after_freq = base * (1 - freq_disc)
+    esi_disc = _esi_discount(esi_score, vessel_built_year)
+    after_esi = after_freq * (1 - esi_disc)
+
+    if special_rate:
+        after_esi = gt * 0.2145
+
+    ext_fee = 0.0
+    if days_in_port > 20:
+        periods = math.floor((days_in_port - 20) / 20) + 1
+        ext_fee = periods * gt * NON_LINER_TARIFFS[mapped_type]
+
+    total = round(after_esi + ext_fee, 2)
+
+    variance = None
+    pass_2pct = None
+    if invoice_amount is not None:
+        variance = abs(total - invoice_amount) / total
+        pass_2pct = variance <= 0.02
+
+    breakdown_lines = [
+        "Antwerp Harbour Dues – ZVR_GT",
+        f"1) Base = GT {gt} × tariff {base_tariff} = {base:.2f} EUR",
+        f"2) Frequency discount = {base:.2f} × {freq_disc*100:.1f}% = {base*freq_disc:.2f} EUR",
+        f"   After frequency discount = {after_freq:.2f} EUR",
+        f"3) ESI discount = {after_freq:.2f} × {esi_disc*100:.1f}% = {after_freq*esi_disc:.2f} EUR",
+        f"   After ESI discount = {after_esi:.2f} EUR",
+    ]
+    if special_rate:
+        breakdown_lines.append(
+            f"4) Special rate applied: GT {gt} × 0.2145 = {after_esi:.2f} EUR"
+        )
+        step_idx = 5
+    else:
+        step_idx = 4
+    breakdown_lines.append(
+        f"{step_idx}) Extended stay fee = {ext_fee:.2f} EUR"
+    )
+    breakdown_lines.append(
+        f"{step_idx+1}) Total = {after_esi:.2f} + {ext_fee:.2f} = {total:.2f} EUR"
+    )
+    breakdown = "\n".join(breakdown_lines)
+
+    summary = {
+        "product_type": "ZVR_GT",
+        "inputs": {
+            "vessel_type_raw": vessel_type_raw,
+            "mapped_type": mapped_type,
+            "service_type": service_type,
+            "gt": gt,
+            "voyage_number": voyage_number,
+            "esi_score": esi_score,
+            "vessel_built_year": vessel_built_year,
+            "special_rate": special_rate,
+            "days_in_port": days_in_port,
+            "invoice_amount": invoice_amount,
+        },
+        "computed": {
+            "base_tariff": base_tariff,
+            "base_eur": round(base, 2),
+            "frequency_discount_pct": freq_disc * 100,
+            "esi_discount_pct": esi_disc * 100,
+            "after_discounts_eur": round(after_esi, 2),
+            "extended_stay_fee_eur": round(ext_fee, 2),
+            "total_eur": total,
+        },
+        "validation": {
+            "variance_pct": variance,
+            "pass_within_2pct": pass_2pct,
+        },
+    }
+
+    return breakdown, summary
+
+
+def calculate_aanlegrecht_tons(
+    *,
+    loaded_tons: float,
+    discharged_tons: float,
+    unit_rate_eur_per_ton: float,
+    invoice_amount: float | None,
+    commodity_group: str = "",
+) -> Tuple[str, Dict]:
+    tons_used = loaded_tons + discharged_tons
+    amount = tons_used * unit_rate_eur_per_ton
+    total = round(amount, 2)
+
+    variance = None
+    pass_2pct = None
+    if invoice_amount is not None:
+        variance = abs(total - invoice_amount) / total
+        pass_2pct = variance <= 0.02
+
+    breakdown_lines = [
+        "Antwerp Harbour Dues – Aanlegrecht Tons",
+        f"1) Tons used = loaded {loaded_tons} + discharged {discharged_tons} = {tons_used}",
+        f"2) Total = {tons_used} × rate {unit_rate_eur_per_ton} = {total:.2f} EUR",
+    ]
+    breakdown = "\n".join(breakdown_lines)
+
+    summary = {
+        "product_type": "Aanlegrecht_Tons",
+        "inputs": {
+            "loaded_tons": loaded_tons,
+            "discharged_tons": discharged_tons,
+            "commodity_group": commodity_group,
+            "unit_rate_eur_per_ton": unit_rate_eur_per_ton,
+            "invoice_amount": invoice_amount,
+        },
+        "computed": {
+            "tons_used": tons_used,
+            "amount_eur": total,
+        },
+        "validation": {
+            "variance_pct": variance,
+            "pass_within_2pct": pass_2pct,
+        },
+    }
+
+    return breakdown, summary
+
+
+def _cli() -> None:
+    p = argparse.ArgumentParser(description="Antwerp harbour dues calculator")
+    sub = p.add_subparsers(dest="product")
+
+    p_zvr = sub.add_parser("ZVR_GT")
+    p_zvr.add_argument("--vessel-type-raw", required=True)
+    p_zvr.add_argument("--gt", type=float, required=True)
+    p_zvr.add_argument("--voyage-number", type=int)
+    p_zvr.add_argument("--is-shortsea", action="store_true")
+    p_zvr.add_argument("--is-liner", action="store_true")
+    p_zvr.add_argument("--esi-score", type=float)
+    p_zvr.add_argument("--vessel-built-year", type=int)
+    p_zvr.add_argument("--special-rate", action="store_true")
+    p_zvr.add_argument("--days-in-port", type=int, default=1)
+    p_zvr.add_argument("--invoice-amount", type=float)
+
+    p_cargo = sub.add_parser("Aanlegrecht_Tons")
+    p_cargo.add_argument("--loaded-tons", type=float, default=0.0)
+    p_cargo.add_argument("--discharged-tons", type=float, default=0.0)
+    p_cargo.add_argument("--unit-rate", type=float, required=True)
+    p_cargo.add_argument("--invoice-amount", type=float)
+    p_cargo.add_argument("--commodity-group", type=str, default="")
+
+    args = p.parse_args()
+
+    if args.product == "ZVR_GT":
+        breakdown, summary = calculate_zvr_gt(
+            vessel_type_raw=args.vessel_type_raw,
+            gt=args.gt,
+            voyage_number=args.voyage_number,
+            is_shortsea=args.is_shortsea,
+            is_liner=args.is_liner,
+            esi_score=args.esi_score,
+            vessel_built_year=args.vessel_built_year,
+            special_rate=args.special_rate,
+            days_in_port=args.days_in_port,
+            invoice_amount=args.invoice_amount,
+        )
+    else:
+        breakdown, summary = calculate_aanlegrecht_tons(
+            loaded_tons=args.loaded_tons,
+            discharged_tons=args.discharged_tons,
+            unit_rate_eur_per_ton=args.unit_rate,
+            invoice_amount=args.invoice_amount,
+            commodity_group=args.commodity_group,
+        )
+
+    print(breakdown)
+    print("\nJSON Summary:\n" + json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    _cli()
+

--- a/2025_tariffs/Antwerp/Code_Interpreter/mooring
+++ b/2025_tariffs/Antwerp/Code_Interpreter/mooring
@@ -1,0 +1,173 @@
+Act as a code interpreter and run the following code. Explain the result and any discrepancy.
+"""
+Antwerp Mooring Fee Calculator
+------------------------------
+
+Rules (summarised):
+1) Base tariff by LOA using MOORING_TARIFFS table.  If LOA > 400m,
+   add extra segments of 5m charged at FRACTION_RATES['mooring'] (=184 EUR).
+2) Time-based supplement: Sunday +50%, else night (19:00–07:00) +25%, else 0.
+3) Location supplement: +30% if location contains "riverquay".
+4) Delay supplement: if delay >45min → 50% of (Base+TimeSuppl+LocSuppl) per started hour beyond 45min.
+5) Reductions: -25% for second call; -50% for short movement.
+6) Cancellation: +50% of Base if cancelled.
+7) Total = Base + TimeSuppl + LocSuppl + DelaySuppl + CancelFee - Reductions.
+"""
+
+from __future__ import annotations
+import argparse
+import datetime as dt
+import json
+import math
+from typing import List, Tuple
+
+MOORING_TARIFFS: List[Tuple[float, float, float]] = [
+    (0, 80.00, 190), (80.01, 90.00, 245), (90.01, 100.00, 252),
+    (100.01, 110.00, 338), (110.01, 120.00, 350), (120.01, 130.00, 398),
+    (130.01, 138.00, 418), (138.01, 146.00, 445), (146.01, 152.00, 499),
+    (152.01, 157.00, 571), (157.01, 160.00, 588), (160.01, 167.50, 624),
+    (167.51, 175.00, 774), (175.01, 182.50, 854), (182.51, 190.00, 909),
+    (190.01, 197.50, 949), (197.51, 205.00, 1003), (205.01, 212.50, 1028),
+    (212.51, 220.00, 1102), (220.01, 227.50, 1155), (227.51, 235.00, 1330),
+    (235.01, 242.50, 1482), (242.51, 250.00, 1544), (250.01, 257.50, 1594),
+    (257.51, 265.00, 1661), (265.01, 272.50, 1720), (272.51, 280.00, 1769),
+    (280.01, 287.50, 1828), (287.51, 295.00, 1956), (295.01, 302.50, 2257),
+    (302.51, 310.00, 2364), (310.01, 317.50, 2581), (317.51, 325.00, 2795),
+    (325.01, 330.00, 3137), (330.01, 335.00, 3482), (335.01, 340.00, 3822),
+    (340.01, 345.00, 3991), (345.01, 350.00, 4143), (350.01, 355.00, 4178),
+    (355.01, 360.00, 4371), (360.01, 365.00, 4559), (365.01, 370.00, 4749),
+    (370.01, 375.00, 4933), (375.01, 380.00, 5118), (380.01, 385.00, 5302),
+    (385.01, 390.00, 5483), (390.01, 395.00, 5669), (395.01, 400.00, 5852)
+]
+
+FRACTION_RATES = {"mooring": 184}
+
+
+def _find_base(loa: float) -> float:
+    for lo, hi, tariff in MOORING_TARIFFS:
+        if lo <= loa <= hi:
+            return tariff
+    # Above table
+    base_400 = MOORING_TARIFFS[-1][2]
+    extra_segments = math.ceil((loa - 400) / 5)
+    return base_400 + extra_segments * FRACTION_RATES["mooring"]
+
+
+def calculate_mooring(
+    *,
+    loa_m: float,
+    service_time: dt.datetime,
+    location: str,
+    delay_minutes: float | None = None,
+    is_second_call: bool = False,
+    is_short_movement: bool = False,
+    is_cancelled: bool = False,
+    billed_amount_eur: float | None = None,
+) -> tuple[str, dict]:
+    base = _find_base(loa_m)
+
+    # Supplements
+    if service_time.weekday() == 6:
+        time_suppl = base * 0.50
+    elif service_time.hour >= 19 or service_time.hour < 7:
+        time_suppl = base * 0.25
+    else:
+        time_suppl = 0.0
+
+    loc_suppl = base * 0.30 if "riverquay" in location.lower() else 0.0
+
+    delay_suppl = 0.0
+    if delay_minutes and delay_minutes > 45:
+        hours_delayed = math.ceil((delay_minutes - 45) / 60)
+        delay_suppl = (base + time_suppl + loc_suppl) * 0.50 * hours_delayed
+
+    reductions = 0.0
+    if is_second_call:
+        reductions += base * 0.25
+    if is_short_movement:
+        reductions += base * 0.50
+
+    cancel_fee = base * 0.50 if is_cancelled else 0.0
+
+    total = base + time_suppl + loc_suppl + delay_suppl + cancel_fee - reductions
+    total = round(total, 2)
+
+    variance = None
+    pass_2pct = None
+    if billed_amount_eur is not None:
+        variance = abs(total - billed_amount_eur) / total
+        pass_2pct = variance <= 0.02
+
+    breakdown_lines = [
+        "Antwerp Mooring Fee Calculation",
+        f"1) Base tariff = {base:.2f} EUR",
+        f"2) Time supplement = {time_suppl:.2f} EUR",
+        f"3) Location supplement = {loc_suppl:.2f} EUR",
+        f"4) Delay supplement = {delay_suppl:.2f} EUR",
+        f"5) Reductions = {reductions:.2f} EUR",
+        f"6) Cancellation fee = {cancel_fee:.2f} EUR",
+        f"7) Total = {base:.2f} + {time_suppl:.2f} + {loc_suppl:.2f} + {delay_suppl:.2f} + {cancel_fee:.2f} - {reductions:.2f} = {total:.2f} EUR",
+    ]
+    breakdown = "\n".join(breakdown_lines)
+
+    summary = {
+        "inputs": {
+            "loa_m": loa_m,
+            "service_time": service_time.isoformat(),
+            "location": location,
+            "delay_minutes": delay_minutes,
+            "is_second_call": is_second_call,
+            "is_short_movement": is_short_movement,
+            "is_cancelled": is_cancelled,
+            "billed_amount_eur": billed_amount_eur,
+        },
+        "computed": {
+            "base_eur": round(base, 2),
+            "time_suppl_eur": round(time_suppl, 2),
+            "loc_suppl_eur": round(loc_suppl, 2),
+            "delay_suppl_eur": round(delay_suppl, 2),
+            "reductions_eur": round(reductions, 2),
+            "cancel_fee_eur": round(cancel_fee, 2),
+            "total_eur": total,
+        },
+        "validation": {
+            "variance_pct": variance,
+            "pass_within_2pct": pass_2pct,
+        },
+    }
+
+    return breakdown, summary
+
+
+def _cli() -> None:
+    p = argparse.ArgumentParser(description="Antwerp mooring calculator")
+    p.add_argument("--loa", type=float, required=True)
+    p.add_argument("--service-time", type=str, required=True, help="ISO datetime")
+    p.add_argument("--location", type=str, required=True)
+    p.add_argument("--delay-minutes", type=float)
+    p.add_argument("--second-call", action="store_true")
+    p.add_argument("--short-movement", action="store_true")
+    p.add_argument("--cancelled", action="store_true")
+    p.add_argument("--billed", type=float)
+    args = p.parse_args()
+
+    st = dt.datetime.fromisoformat(args.service_time)
+    breakdown, summary = calculate_mooring(
+        loa_m=args.loa,
+        service_time=st,
+        location=args.location,
+        delay_minutes=args.delay_minutes,
+        is_second_call=args.second_call,
+        is_short_movement=args.short_movement,
+        is_cancelled=args.cancelled,
+        billed_amount_eur=args.billed,
+    )
+
+    print("Calculated Mooring:", summary["computed"]["total_eur"], "EUR")
+    print(breakdown)
+    print("\nJSON Summary:\n" + json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    _cli()
+

--- a/2025_tariffs/Antwerp/Code_Interpreter/pilotage_out
+++ b/2025_tariffs/Antwerp/Code_Interpreter/pilotage_out
@@ -1,0 +1,208 @@
+Act like a code interpreter and execute the following code with the variables injected, then explain the result and any discrepancy.
+"""
+Antwerp Pilotage-Out (Block-Size) Fee Calculator
+================================================
+
+Goal
+----
+Calculate the Antwerp pilotage-out fee using the block-size method with exact tariffs.
+
+Data usage rule (priority):
+1) Use provided variables first.
+2) If missing, try to parse from invoice text.
+3) If still missing, mark as "not provided".
+
+BAF must come from the invoice; if not found we compute with BAF=0 and warn.
+
+Block size uses draught in **meters**:
+  block_size = length_m * breadth_m * draught_m
+If invoice text provides draught in dm, convert dm→m.
+"""
+
+from __future__ import annotations
+import argparse
+import json
+import math
+import os
+import re
+import importlib.util
+from pathlib import Path
+from typing import Dict, List, Tuple, Optional, Any
+
+# ---------------------------------------------------------------------------
+# Reuse tariff table and helpers from pilotage_in
+# ---------------------------------------------------------------------------
+
+_spec = importlib.util.spec_from_file_location(
+    "pilotage_in", Path(__file__).with_name("pilotage_in")
+)
+_pi = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_pi)  # type: ignore
+
+ALLOWED_ROUTE_KEYS = _pi.ALLOWED_ROUTE_KEYS
+TARIFF_TABLE = _pi.TARIFF_TABLE
+_parse_number = _pi._parse_number
+parse_invoice_text = _pi.parse_invoice_text
+
+
+def calculate_pilotage_out(
+    *,
+    length_m: float | None,
+    breadth_m: float | None,
+    max_summer_draught_m: float | None,
+    routes: List[str] | None,
+    baf_percentage: float | None,
+    cancellation_fee: float | None,
+    delay_fee: float | None,
+    storm_pilot_fee: float | None,
+    special_case_fee: float | None,
+    custom_volume_discount: float | None,
+    invoice_text: str | None = None,
+) -> Tuple[str, Dict]:
+    parsed = parse_invoice_text(invoice_text or "")
+
+    length_m = float(length_m) if length_m is not None else None
+    breadth_m = float(breadth_m) if breadth_m is not None else None
+    draught_m = float(max_summer_draught_m) if max_summer_draught_m is not None else parsed.get("draught_m")
+    routes = routes or []
+
+    baf_percentage = (
+        baf_percentage if baf_percentage is not None else parsed.get("baf_percentage")
+    )
+    cancellation_fee = cancellation_fee if cancellation_fee is not None else parsed.get("cancellation_fee", 0.0)
+    delay_fee = delay_fee if delay_fee is not None else parsed.get("delay_fee", 0.0)
+    storm_pilot_fee = storm_pilot_fee if storm_pilot_fee is not None else parsed.get("storm_pilot_fee", 0.0)
+    special_case_fee = special_case_fee if special_case_fee is not None else parsed.get("special_case_fee", 0.0)
+    custom_volume_discount = custom_volume_discount or 0.0
+
+    warnings: List[str] = []
+    notes: List[str] = []
+
+    if length_m is None or breadth_m is None or draught_m is None or not routes:
+        raise ValueError("length_m, breadth_m, draught_m and routes are required")
+
+    block_size = length_m * breadth_m * draught_m
+
+    # Determine base fees per route
+    route_base_fees: List[Dict[str, Any]] = []
+    for route in routes:
+        if route not in ALLOWED_ROUTE_KEYS:
+            raise ValueError(f"Unknown route: {route}")
+        row = TARIFF_TABLE[-1]
+        for r in TARIFF_TABLE:
+            if r["min"] <= block_size <= r["max"]:
+                row = r
+                break
+        fee = row[route]
+        route_base_fees.append({
+            "route": route,
+            "range_min": row["min"],
+            "range_max": row["max"],
+            "base_fee_eur": fee,
+        })
+
+    total_base_fee = sum(r["base_fee_eur"] for r in route_base_fees)
+
+    additional_fees_total = (cancellation_fee or 0.0) + (delay_fee or 0.0) + (storm_pilot_fee or 0.0) + (special_case_fee or 0.0)
+    volume_discount_value = total_base_fee * (custom_volume_discount / 100.0)
+    baf_pct_used = baf_percentage if baf_percentage is not None else 0.0
+    if baf_percentage is None:
+        warnings.append("BAF percentage missing; treated as 0")
+    baf_amount = total_base_fee * (baf_pct_used / 100.0)
+
+    final_amount = total_base_fee + additional_fees_total - volume_discount_value + baf_amount
+
+    def money(x: float) -> str:
+        return f"€{x:,.2f}"
+
+    lines = []
+    lines.append("Antwerp Pilotage-Out (Block-Size) – Calculation Breakdown")
+    lines.append("")
+    lines.append(f"1) Block size = {length_m} × {breadth_m} × {draught_m} = {block_size:,.2f}")
+    lines.append("2) Base fee per route:")
+    for r in route_base_fees:
+        lines.append(
+            f"   - {r['route']}: bracket [{r['range_min']:,}-{r['range_max']:,}] -> {money(r['base_fee_eur'])}"
+        )
+    lines.append(f"   total_base_fee = {money(total_base_fee)}")
+    lines.append(
+        f"3) Additional fees = {money(cancellation_fee or 0)} (cancellation) + {money(delay_fee or 0)} (delay) + "
+        f"{money(storm_pilot_fee or 0)} (storm pilot) + {money(special_case_fee or 0)} (special) = {money(additional_fees_total)}"
+    )
+    lines.append(f"4) Volume discount = total_base_fee × {custom_volume_discount:.2f}% = {money(volume_discount_value)}")
+    lines.append(f"5) BAF = total_base_fee × {baf_pct_used:.2f}% = {money(baf_amount)}")
+    lines.append(
+        f"6) Final amount = {money(total_base_fee)} + {money(additional_fees_total)} - {money(volume_discount_value)} + {money(baf_amount)} = {money(final_amount)}"
+    )
+    if warnings:
+        lines.append("")
+        lines.append("WARNINGS:")
+        for w in warnings:
+            lines.append(f"- {w}")
+    breakdown = "\n".join(lines)
+
+    summary = {
+        "inputs": {
+            "length_m": length_m,
+            "breadth_m": breadth_m,
+            "draught_m": draught_m,
+            "routes": routes,
+            "baf_percentage": baf_percentage if baf_percentage is not None else "not provided",
+            "cancellation_fee": cancellation_fee or 0.0,
+            "delay_fee": delay_fee or 0.0,
+            "storm_pilot_fee": storm_pilot_fee or 0.0,
+            "special_case_fee": special_case_fee or 0.0,
+            "custom_volume_discount": custom_volume_discount or 0.0,
+        },
+        "computed": {
+            "block_size": round(block_size, 2),
+            "route_base_fees": route_base_fees,
+            "total_base_fee_eur": round(total_base_fee, 2),
+            "additional_fees_total_eur": round(additional_fees_total, 2),
+            "volume_discount_value_eur": round(volume_discount_value, 2),
+            "baf_amount_eur": round(baf_amount, 2),
+            "final_amount_eur": round(final_amount, 2),
+        },
+        "warnings": warnings,
+        "notes": notes,
+    }
+
+    return breakdown, summary
+
+
+def _cli() -> None:
+    p = argparse.ArgumentParser(description="Antwerp Pilotage-Out fee calculator")
+    p.add_argument("--length-m", type=float)
+    p.add_argument("--breadth-m", type=float)
+    p.add_argument("--draught-m", type=float)
+    p.add_argument("--route", action="append")
+    p.add_argument("--baf-percentage", type=float)
+    p.add_argument("--cancellation-fee", type=float, default=0.0)
+    p.add_argument("--delay-fee", type=float, default=0.0)
+    p.add_argument("--storm-pilot-fee", type=float, default=0.0)
+    p.add_argument("--special-case-fee", type=float, default=0.0)
+    p.add_argument("--custom-volume-discount", type=float, default=0.0)
+    p.add_argument("--invoice-text", type=str)
+    args = p.parse_args()
+
+    breakdown, summary = calculate_pilotage_out(
+        length_m=args.length_m,
+        breadth_m=args.breadth_m,
+        max_summer_draught_m=args.draught_m,
+        routes=args.route,
+        baf_percentage=args.baf_percentage,
+        cancellation_fee=args.cancellation_fee,
+        delay_fee=args.delay_fee,
+        storm_pilot_fee=args.storm_pilot_fee,
+        special_case_fee=args.special_case_fee,
+        custom_volume_discount=args.custom_volume_discount,
+        invoice_text=args.invoice_text,
+    )
+
+    print(breakdown)
+    print("\nJSON Summary:\n" + json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    _cli()
+

--- a/2025_tariffs/Antwerp/Code_Interpreter/unmooring
+++ b/2025_tariffs/Antwerp/Code_Interpreter/unmooring
@@ -1,0 +1,167 @@
+Act as a code interpreter and run the following code. Explain the result and any discrepancy.
+"""
+Antwerp Unmooring Fee Calculator
+--------------------------------
+
+Rules mirror those for mooring but with UNMOORING_TARIFFS and FRACTION_RATES['unmooring']=109.
+Steps:
+1) Base tariff by LOA using UNMOORING_TARIFFS. If LOA>400m add 5m segments at 109 EUR.
+2) Time supplement: Sunday +50%, else night (19:00–07:00) +25%, else 0.
+3) Location supplement: +30% if location contains "riverquay".
+4) Delay supplement: if delay>45min → 50% of (Base+TimeSuppl+LocSuppl) per started hour beyond 45min.
+5) Reductions: -25% for second call; -50% for short movement.
+6) Cancellation: +50% of Base if cancelled.
+7) Total = Base + TimeSuppl + LocSuppl + DelaySuppl + CancelFee - Reductions.
+"""
+
+from __future__ import annotations
+import argparse
+import datetime as dt
+import json
+import math
+from typing import List, Tuple
+
+UNMOORING_TARIFFS: List[Tuple[float, float, float]] = [
+  (0, 80.00, 113),(80.01, 90.00, 147),(90.01,100.00,151),(100.01,110.00,203),
+  (110.01,120.00,211),(120.01,130.00,241),(130.01,138.00,253),(138.01,146.00,268),
+  (146.01,152.00,300),(152.01,157.00,342),(157.01,160.00,353),(160.01,167.50,375),
+  (167.51,175.00,466),(175.01,182.50,513),(182.51,190.00,546),(190.01,197.50,570),
+  (197.51,205.00,609),(205.01,212.50,624),(212.51,220.00,668),(220.01,227.50,701),
+  (227.51,235.00,807),(235.01,242.50,899),(242.51,250.00,938),(250.01,257.50,968),
+  (257.51,265.00,1008),(265.01,272.50,1044),(272.51,280.00,1072),(280.01,287.50,1111),
+  (287.51,295.00,1188),(295.01,302.50,1369),(302.51,310.00,1434),(310.01,317.50,1585),
+  (317.51,325.00,1717),(325.01,330.00,1927),(330.01,335.00,2136),(335.01,340.00,2344),
+  (340.01,345.00,2446),(345.01,350.00,2542),(350.01,355.00,2563),(355.01,360.00,2682),
+  (360.01,365.00,2795),(365.01,370.00,2909),(370.01,375.00,3017),(375.01,380.00,3126),
+  (380.01,385.00,3235),(385.01,390.00,3341),(390.01,395.00,3450),(395.01,400.00,3559)
+]
+
+FRACTION_RATES = {"unmooring": 109}
+
+
+def _find_base(loa: float) -> float:
+    for lo, hi, tariff in UNMOORING_TARIFFS:
+        if lo <= loa <= hi:
+            return tariff
+    base_400 = UNMOORING_TARIFFS[-1][2]
+    extra_segments = math.ceil((loa - 400) / 5)
+    return base_400 + extra_segments * FRACTION_RATES["unmooring"]
+
+
+def calculate_unmooring(
+    *,
+    loa_m: float,
+    service_time: dt.datetime,
+    location: str,
+    delay_minutes: float | None = None,
+    is_second_call: bool = False,
+    is_short_movement: bool = False,
+    is_cancelled: bool = False,
+    billed_amount_eur: float | None = None,
+) -> tuple[str, dict]:
+    base = _find_base(loa_m)
+
+    if service_time.weekday() == 6:
+        time_suppl = base * 0.50
+    elif service_time.hour >= 19 or service_time.hour < 7:
+        time_suppl = base * 0.25
+    else:
+        time_suppl = 0.0
+
+    loc_suppl = base * 0.30 if "riverquay" in location.lower() else 0.0
+
+    delay_suppl = 0.0
+    if delay_minutes and delay_minutes > 45:
+        hours_delayed = math.ceil((delay_minutes - 45) / 60)
+        delay_suppl = (base + time_suppl + loc_suppl) * 0.50 * hours_delayed
+
+    reductions = 0.0
+    if is_second_call:
+        reductions += base * 0.25
+    if is_short_movement:
+        reductions += base * 0.50
+
+    cancel_fee = base * 0.50 if is_cancelled else 0.0
+
+    total = base + time_suppl + loc_suppl + delay_suppl + cancel_fee - reductions
+    total = round(total, 2)
+
+    variance = None
+    pass_2pct = None
+    if billed_amount_eur is not None:
+        variance = abs(total - billed_amount_eur) / total
+        pass_2pct = variance <= 0.02
+
+    breakdown_lines = [
+        "Antwerp Unmooring Fee Calculation",
+        f"1) Base tariff = {base:.2f} EUR",
+        f"2) Time supplement = {time_suppl:.2f} EUR",
+        f"3) Location supplement = {loc_suppl:.2f} EUR",
+        f"4) Delay supplement = {delay_suppl:.2f} EUR",
+        f"5) Reductions = {reductions:.2f} EUR",
+        f"6) Cancellation fee = {cancel_fee:.2f} EUR",
+        f"7) Total = {base:.2f} + {time_suppl:.2f} + {loc_suppl:.2f} + {delay_suppl:.2f} + {cancel_fee:.2f} - {reductions:.2f} = {total:.2f} EUR",
+    ]
+    breakdown = "\n".join(breakdown_lines)
+
+    summary = {
+        "inputs": {
+            "loa_m": loa_m,
+            "service_time": service_time.isoformat(),
+            "location": location,
+            "delay_minutes": delay_minutes,
+            "is_second_call": is_second_call,
+            "is_short_movement": is_short_movement,
+            "is_cancelled": is_cancelled,
+            "billed_amount_eur": billed_amount_eur,
+        },
+        "computed": {
+            "base_eur": round(base, 2),
+            "time_suppl_eur": round(time_suppl, 2),
+            "loc_suppl_eur": round(loc_suppl, 2),
+            "delay_suppl_eur": round(delay_suppl, 2),
+            "reductions_eur": round(reductions, 2),
+            "cancel_fee_eur": round(cancel_fee, 2),
+            "total_eur": total,
+        },
+        "validation": {
+            "variance_pct": variance,
+            "pass_within_2pct": pass_2pct,
+        },
+    }
+
+    return breakdown, summary
+
+
+def _cli() -> None:
+    p = argparse.ArgumentParser(description="Antwerp unmooring calculator")
+    p.add_argument("--loa", type=float, required=True)
+    p.add_argument("--service-time", type=str, required=True, help="ISO datetime")
+    p.add_argument("--location", type=str, required=True)
+    p.add_argument("--delay-minutes", type=float)
+    p.add_argument("--second-call", action="store_true")
+    p.add_argument("--short-movement", action="store_true")
+    p.add_argument("--cancelled", action="store_true")
+    p.add_argument("--billed", type=float)
+    args = p.parse_args()
+
+    st = dt.datetime.fromisoformat(args.service_time)
+    breakdown, summary = calculate_unmooring(
+        loa_m=args.loa,
+        service_time=st,
+        location=args.location,
+        delay_minutes=args.delay_minutes,
+        is_second_call=args.second_call,
+        is_short_movement=args.short_movement,
+        is_cancelled=args.cancelled,
+        billed_amount_eur=args.billed,
+    )
+
+    print("Calculated Unmooring:", summary["computed"]["total_eur"], "EUR")
+    print(breakdown)
+    print("\nJSON Summary:\n" + json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    _cli()
+

--- a/2025_tariffs/Antwerp/Code_Interpreter/waste_Fees
+++ b/2025_tariffs/Antwerp/Code_Interpreter/waste_Fees
@@ -1,0 +1,144 @@
+Act as a code interpreter and execute the following code. If there is a discrepancy, explain it.
+"""
+Compulsory Waste Fee - Port of Antwerp
+--------------------------------------
+
+Constants for the fixed fee and rate per GT are expected to be provided via
+injected variables. Only if a constant is missing do we attempt to parse it
+from the invoice text.
+
+Inputs:
+  gt_size               (float)  # gross tonnage
+  fixed_fee             (float)  # from injection or invoice
+  rate_per_gt           (float)  # from injection or invoice
+  is_iso_certified      (bool)
+  is_short_movement     (bool)
+  invoice_amount_eur    (float)
+  invoice_text          (str) optional
+
+Outputs:
+  breakdown text and JSON summary with ±2% validation against invoice_amount_eur.
+"""
+
+from __future__ import annotations
+import argparse
+import json
+import re
+
+SHORT_VOYAGE_DISCOUNT_RATE = 0.05
+
+
+def _parse_invoice_constants(text: str) -> dict:
+    out: dict = {}
+    if not text:
+        return out
+    m_fixed = re.search(r"fixed fee\D*([0-9][\d.,]*)", text, re.IGNORECASE)
+    if m_fixed:
+        out["fixed_fee"] = float(m_fixed.group(1).replace(",", "."))
+    m_rate = re.search(r"rate\D*([0-9][\d.,]*)\s*eur/?gt", text, re.IGNORECASE)
+    if m_rate:
+        out["rate_per_gt"] = float(m_rate.group(1).replace(",", "."))
+    return out
+
+
+def calculate_waste_fee(
+    *,
+    gt_size: float,
+    fixed_fee: float | None,
+    rate_per_gt: float | None,
+    is_iso_certified: bool = False,
+    is_short_movement: bool = False,
+    invoice_amount: float | None = None,
+    invoice_text: str | None = None,
+) -> tuple[str, dict]:
+    parsed = _parse_invoice_constants(invoice_text or "")
+    fixed_fee = fixed_fee if fixed_fee is not None else parsed.get("fixed_fee")
+    rate_per_gt = rate_per_gt if rate_per_gt is not None else parsed.get("rate_per_gt")
+
+    warnings = []
+    if fixed_fee is None:
+        warnings.append("fixed_fee not provided")
+        fixed_fee = 0.0
+    if rate_per_gt is None:
+        warnings.append("rate_per_gt not provided")
+        rate_per_gt = 0.0
+    variable_fee = gt_size * rate_per_gt
+    initial_fee = fixed_fee + variable_fee
+
+    iso_discount = initial_fee * 0.10 if is_iso_certified else 0.0
+    short_discount = (
+        initial_fee * SHORT_VOYAGE_DISCOUNT_RATE if is_short_movement else 0.0
+    )
+
+    total_fee = initial_fee - iso_discount - short_discount
+
+    breakdown_lines = [
+        "Compulsory Waste Fee Calculation - Port of Antwerp",
+        f"1) Variable fee = GT {gt_size} × {rate_per_gt:.4f} = {variable_fee:.2f} EUR",
+        f"2) Initial fee = fixed {fixed_fee:.2f} + variable {variable_fee:.2f} = {initial_fee:.2f} EUR",
+        f"3) ISO discount = {initial_fee:.2f} × 10% = {iso_discount:.2f} EUR",
+        f"4) Short voyage discount = {initial_fee:.2f} × {SHORT_VOYAGE_DISCOUNT_RATE*100:.0f}% = {short_discount:.2f} EUR",
+        f"5) Total waste fee = {initial_fee:.2f} - {iso_discount:.2f} - {short_discount:.2f} = {total_fee:.2f} EUR",
+    ]
+
+    variance = None
+    pass_2pct = None
+    if invoice_amount is not None:
+        variance = abs(total_fee - invoice_amount) / total_fee
+        pass_2pct = variance <= 0.02
+
+    summary = {
+        "inputs": {
+            "gt_size": gt_size,
+            "is_iso_certified": is_iso_certified,
+            "is_short_movement": is_short_movement,
+            "fixed_waste_fee_eur": fixed_fee,
+            "waste_tariff_per_gt_eur": rate_per_gt,
+            "short_voyage_discount_rate": SHORT_VOYAGE_DISCOUNT_RATE,
+            "invoice_amount": invoice_amount,
+        },
+        "calculation": {
+            "variable_fee_eur": round(variable_fee, 2),
+            "initial_fee_eur": round(initial_fee, 2),
+            "iso_discount_eur": round(iso_discount, 2),
+            "short_voyage_discount_eur": round(short_discount, 2),
+            "total_fee_eur": round(total_fee, 2),
+        },
+        "validation": {
+            "variance_pct": variance,
+            "pass_within_2pct": pass_2pct,
+        },
+        "warnings": warnings,
+    }
+
+    return "\n".join(breakdown_lines), summary
+
+
+def _cli() -> None:
+    p = argparse.ArgumentParser(description="Antwerp compulsory waste fee calculator.")
+    p.add_argument("--gt-size", type=float, required=True)
+    p.add_argument("--fixed-fee", type=float)
+    p.add_argument("--rate-per-gt", type=float)
+    p.add_argument("--iso", action="store_true", help="ISO 14001 certified")
+    p.add_argument("--short", action="store_true", help="Short voyage discount")
+    p.add_argument("--invoice-amount", type=float)
+    p.add_argument("--invoice-text", type=str)
+    args = p.parse_args()
+
+    breakdown, summary = calculate_waste_fee(
+        gt_size=args.gt_size,
+        fixed_fee=args.fixed_fee,
+        rate_per_gt=args.rate_per_gt,
+        is_iso_certified=args.iso,
+        is_short_movement=args.short,
+        invoice_amount=args.invoice_amount,
+        invoice_text=args.invoice_text,
+    )
+
+    print(breakdown)
+    print("\nJSON Summary:\n" + json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    _cli()
+

--- a/2025_tariffs/Antwerp/Prompts/harbour_dues
+++ b/2025_tariffs/Antwerp/Prompts/harbour_dues
@@ -1,142 +1,58 @@
-Task
-- For each Antwerp harbour-dues invoice line, identify the product type and compute the amount accordingly.
-- Two distinct products:
-  1) ZVR_GT (Zeevaartrechten) — GT-based harbour dues
-  2) Aanlegrecht_Tons — cargo-based dues on loaded/discharged tonnage
-- Reconcile computed totals against invoice and flag ±2% variance.
+Antwerp Harbour Dues
+---------------------
 
-Product Routing (from line description)
-- If description contains “aanlegrecht” and “geladen/geloste tonnen” (or equivalent), classify as Aanlegrecht_Tons.
-- Else if description contains “Zeevaartrechten (ZVR)” and no “aanlegrecht”, classify as ZVR_GT.
-- If ambiguous, flag and request clarification.
+Use values provided through injected variables. Only read the invoice if a required value is missing; if still missing, report it.
+Return a numbered, human-readable breakdown and the final amount. If an invoice amount is available, show the variance and note Pass/Fail at ±2%.
 
-Shared Inputs (parsed from invoice and call data)
-- vessel_type_raw (e.g., tanker, bulkcarrier, container, roro, reefer, other)
-INPUTS SHOULD ALWAYS BE TAKEN FROM THE INSTRUCTIONS. IF NOT FOUND IN THE INSTRUCTIONS, THEN YOU SHOULD LOOK AT THE INVOICE. 
+Products
+========
+1. ZVR_GT – GT-based harbour dues
+   Steps:
+   1. Map vessel type:
+      tanker→tanker, bulkcarrier→bulk, container→containership,
+      roro→roro, reefer→reefer, anything else→other.
+   2. Service type:
+      - shortsea if IsShortsea
+      - deepsea if IsLiner
+      - otherwise non-liner
+   3. Base tariff (€/GT):
+      LINER_TARIFFS = { containership: {deepsea:0.3275, shortsea:0.2629},
+                        roro:{deepsea:0.2237, shortsea:0.2237},
+                        tanker:{deepsea:0.4752, shortsea:0.4752},
+                        reefer:{deepsea:0.3621, shortsea:0.3621},
+                        bulk:{deepsea:0.3621, shortsea:0.3621},
+                        other:{deepsea:0.5322, shortsea:0.5322} }
+      NON_LINER_TARIFFS = { containership:0.8072, roro:0.6243,
+                            tanker:0.9337, reefer:0.7623,
+                            bulk:0.7623, other:0.9337 }
+      Base = GT × selected tariff.
+   4. Frequency discount by VoyageNumber (liners only):
+      deepsea: 53–150→10%, 151–200→20%, ≥201→30%
+      shortsea: 27–52→25%, ≥53→50%
+      AfterFreq = Base × (1 - discount).
+   5. ESI discount by ESI_score and VesselBuiltYear:
+      70.1–100→15%; 50.1–70.09→10%;
+      31–50.09 and built ≤2010→4%
+      AfterESI = AfterFreq × (1 - discount).
+   6. Special rate override:
+      If SpecialRate = True → AfterESI = GT × 0.2145
+      (skip steps 3–5).
+   7. Extended stay fee:
+      If DaysInPort > 20:
+         periods = floor((DaysInPort-20)/20) + 1
+         ExtFee = periods × GT × NON_LINER_TARIFFS[mapped_type]
+      Else ExtFee = 0
+   8. Total = AfterESI + ExtFee
 
-- GT (gross tonnage)
-- VoyageNumber (integer, if available)
-- IsShortsea (bool), IsLiner (bool)
-- ESI_score (float), VesselBuiltYear (int)
-- SpecialRate (bool)
-- DaysInPort (integer)
-- InvoiceAmountExclVAT (float)
-- service_date (for tariff-year validity; if unknown, state assumption)
+2. Aanlegrecht_Tons – cargo dues
+   Steps:
+   1. TonsUsed = loaded_tons + discharged_tons
+   2. Amount = TonsUsed × unit_rate_eur_per_ton
+   3. Total = round(Amount, 2)
 
-----------------------------------------------------------------------
-A) ZVR_GT — GT-based Harbour Dues
-----------------------------------------------------------------------
-
-1) Map vessel type
-- Map to one of: tanker, bulk, containership, roro, reefer, other
-  Mapping:
-  - tanker → tanker
-  - bulkcarrier → bulk
-  - container → containership
-  - roro → roro
-  - reefer → reefer
-  - other → other
-
-2) Determine service_type
-- If IsShortsea = True → service_type = "shortsea"
-- Else if IsLiner = True → service_type = "deepsea"
-- Else → service_type = "non-liner"
-
-3) Base tariff (€/GT)
-- Liner:
-  - containership: deepsea scheldt 0.3275; shortsea 0.2629 (use “scheldt” branch when applicable)
-  - roro: deepsea 0.2237; shortsea 0.2237
-  - tanker: deepsea 0.4752; shortsea 0.4752
-  - reefer: deepsea 0.3621; shortsea 0.3621
-  - bulk: deepsea 0.3621; shortsea 0.3621
-  - other: deepsea 0.5322; shortsea 0.5322
-- Non-liner:
-  - containership: scheldt 0.8072 (locks 0.7623 not used here)
-  - roro: 0.6243
-  - tanker: 0.9337
-  - reefer: 0.7623
-  - bulk: 0.7623
-  - other: 0.9337
-
-4) Base dues
-- Base = GT × BaseTariff
-
-5) Frequency discount (liners only; based on VoyageNumber)
-- If service_type = deepsea:
-  - 53–150 → 10%
-  - 151–200 → 20%
-  - 201+ → 30%
-- If service_type = shortsea:
-  - 27–52 → 25%
-  - 53+ → 50%
-- BaseAfterFreq = Base × (1 - FreqDiscount)
-
-6) ESI discount (apply on BaseAfterFreq)
-- If 70.1–100 → 15%
-- If 50.1–70.09 → 10%
-- If 31.0–50.09 → 4% (skip this 4% tier if VesselBuiltYear > 2010)
-- AfterESI = BaseAfterFreq × (1 - ESIDiscount)
-
-7) Special rate override
-- If SpecialRate = True → AfterESI = GT × 0.2145 (override all above)
-
-8) Extended stay (>20 days)
-- If DaysInPort > 20:
-  - periods = floor((DaysInPort - 20)/20) + 1
-  - NON_LINER_TARIFFS mapped by vessel type:
-    containership=0.8072, roro=0.6243, tanker=0.9337, reefer=0.7623, bulk=0.7623, other=0.9337
-  - ExtFee = periods × GT × NON_LINER_TARIFFS[mapped_type]
-  - Total = AfterESI + ExtFee
-- Else:
-  - Total = AfterESI
-
-9) Validation
-- FinalAmountEUR = round(Total, 2)
-- Pass if |FinalAmountEUR - InvoiceAmountExclVAT| / FinalAmountEUR ≤ 0.02
-- Else, flag mismatch and list possible causes:
-  wrong base tariff, missing liner frequency, ESI tier, special rate override, or extended stay.
-
-Constraints
-- Do NOT include cargo dues (e.g., 0.2062 €/t) in ZVR_GT; those are Aanlegrecht_Tons and must be validated separately.
-
-Output (ZVR_GT)
-- FinalAmountEUR
-- Breakdown summary: GT, mapped_type, service_type, base tariff, Base, Freq%, ESI%, SpecialRate used?, DaysInPort, ExtFee, Total, Pass/Fail.
-
-----------------------------------------------------------------------
-B) Aanlegrecht_Tons — Cargo-based Dues (Loaded/Discharged Tons)
-----------------------------------------------------------------------
-
-1) Inputs
-- loaded_tons, discharged_tons
-- commodity_group (e.g., “minerale oliën”)
-- unit_rate_eur_per_ton:
-  - Use tariff table by commodity group (example known: minerale oliën = 0.2062 €/t).
-  - If the invoice provides the unit price, validate against tariff; if mismatch, note but use invoice rate for reconciliation.
-
-2) Quantity basis
-- TonsUsed = loaded_tons + discharged_tons, unless the invoice explicitly specifies only one (use the invoice’s stated basis).
-
-3) Amount
-- Amount = TonsUsed × unit_rate_eur_per_ton
-
-4) Validation
-- FinalAmountEUR = round(Amount, 2)
-- Pass if |FinalAmountEUR - InvoiceAmountExclVAT| / FinalAmountEUR ≤ 0.02
-- Else, flag mismatch (likely wrong commodity group or wrong €/t).
-
-Constraints
-- Do NOT mix with ZVR_GT logic; Aanlegrecht_Tons is separate and typically not affected by liner frequency, ESI, special rate, or extended stay unless a published rule states otherwise.
-
-Output (Aanlegrecht_Tons)
-- FinalAmountEUR
-- Breakdown summary: commodity_group, TonsUsed, €/t, Amount, Pass/Fail.
-
-----------------------------------------------------------------------
-General Output Fields (for both products)
-- product_type: "ZVR_GT" or "Aanlegrecht_Tons"
-- inputs used
-- unit_rate and source
-- FinalAmountEUR
-- variance% vs invoice and Pass/Fail at ±2%
-- notes: tariff-year assumption, any missing data, or invoice-provided overrides
+Output
+------
+For each product report:
+- Final amount in EUR
+- Numbered step-by-step breakdown
+- Invoice variance and Pass/Fail if invoice amount given

--- a/2025_tariffs/Antwerp/Prompts/mooring
+++ b/2025_tariffs/Antwerp/Prompts/mooring
@@ -1,49 +1,32 @@
-1) Base tariff by LOA:
-   - Find the row where LOA_m ∈ [from, to] (inclusive) in the MOORING_TARIFFS table below.
-   - Base = that row’s tariff.
-   - If LOA_m > 400:
-       - Take the 400.00m band’s base and add extra segments:
-         extra_segments = ceil((LOA_m - 400) / 5)
-         Base += extra_segments × FRACTION_RATES["mooring"]
-       - FRACTION_RATES["mooring"] = 184 (EUR per extra 5m)
-   - If no band matches: return an error.
+Antwerp Mooring Fee
+-------------------
 
-2) Time-based supplement (mutually exclusive):
-   - If ServiceTimeLocal is on Sunday (weekday = 6): TimeSuppl = Base × 0.50
-   - Else if ServiceTimeLocal hour is ≥ 19 or < 7: TimeSuppl = Base × 0.25
-   - Else: TimeSuppl = 0
+Use injected variables first. Only consult the invoice when a value is missing; if still absent, state it.
+Return a numbered, human-readable breakdown and the final amount. If a billed amount is known, show the variance and mark Pass/Fail at ±2%.
 
-3) Location supplement:
-   - If Location contains "riverquay" (case-insensitive): LocSuppl = Base × 0.30
-   - Else: LocSuppl = 0
+Steps
+1. Base tariff by LOA:
+   - Find the row where LOA_m is between "from" and "to" in MOORING_TARIFFS.
+   - If LOA_m > 400: extra_segments = ceil((LOA_m-400)/5);
+     Base += extra_segments × 184 (FRACTION_RATES["mooring"]).
+2. Time supplement (choose one):
+   - Sunday → +50% of Base
+   - Night (19:00–07:00) → +25% of Base
+   - Otherwise 0
+3. Location supplement: +30% of Base if Location contains "riverquay".
+4. Delay supplement:
+   - If DelayMinutes > 45:
+       HoursDelayed = ceil((DelayMinutes-45)/60)
+       DelaySuppl = (Base + TimeSuppl + LocSuppl) × 0.50 × HoursDelayed
+   - Else 0
+5. Reductions:
+   - −25% of Base if IsSecondCall
+   - −50% of Base if IsShortMovement
+6. Cancellation fee: Base × 0.50 if IsCancelled else 0
+7. Total = Base + TimeSuppl + LocSuppl + DelaySuppl + CancelFee − Reductions
+8. Validate against invoice if provided.
 
-4) Delay supplement:
-   - If delay is known and > 45 minutes:
-       - HoursDelayed = ceil((DelayMinutes - 45)/60)
-       - DelaySuppl = (Base + TimeSuppl + LocSuppl) × 0.50 × HoursDelayed
-   - Else: DelaySuppl = 0
-   - If delay unknown: assume 0 and state assumption.
-
-5) Reductions:
-   - Reductions = 0
-   - If IsSecondCall: Reductions += Base × 0.25
-   - If IsShortMovement: Reductions += Base × 0.50
-
-6) Cancellation:
-   - CancelFee = Base × 0.50 if IsCancelled else 0
-
-7) Final amount:
-   - Total = Base + TimeSuppl + LocSuppl + DelaySuppl + CancelFee - Reductions
-   - Round to 2 decimals.
-
-8) Validation:
-   - Accept if |Total - BilledAmountEUR| / Total ≤ 0.02 (±2%).
-   - Otherwise, flag mismatch and explain briefly which components drive the difference
-     (e.g., wrong LOA band, night/Sunday not applied, riverquay not applied, reductions/cancellation/ delay not considered).
-
-CHECK THE INVOICE. THERE are certain things that we cannot capture without the invoice such as Extra Boatmen or Extra Motorboat. Those should directly be added from the invoice itself. If it is under Mooring services, also add them to your final answer.
-
-Antwerp MOORING_TARIFFS (EUR):
+MOORING_TARIFFS (EUR):
 [
     (0, 80.00, 190),
     (80.01, 90.00, 245),
@@ -94,13 +77,4 @@ Antwerp MOORING_TARIFFS (EUR):
     (390.01, 395.00, 5669),
     (395.01, 400.00, 5852)
 ]
-
-Additional constants:
-- FRACTION_RATES["mooring"] = 184  (EUR per 5m beyond 400m)
-- Night window: 19:00–07:00 → +25% (night)
-- Sunday: +50% (overrides night if both)
-
-Output:
-- “Calculated Mooring: X EUR”
-- A short breakdown: Base, TimeSuppl, LocSuppl, DelaySuppl, Reductions, CancelFee, Total
-- Pass/Fail vs ±2% with one-line reason if fail.
+Fraction rate beyond 400m: 184 EUR per 5m.

--- a/2025_tariffs/Antwerp/Prompts/pilotage_in
+++ b/2025_tariffs/Antwerp/Prompts/pilotage_in
@@ -1,4 +1,6 @@
-Goal: Calculate the Antwerp pilotage-in fee using the block-size method with exact tariffs. Provide a step-by-step breakdown and a JSON summary.
+Goal: Calculate the Antwerp pilotage-in fee using the block-size method with exact tariffs.
+Use injected variables first; consult the invoice only if a value is missing.
+Return a numbered, human-readable breakdown followed by a JSON summary.
 
 IMPORTANT:
 IN THE INVOICE There will be VBS. Do not consider that when you validate your answer. That is another Line Item, not related to the actual Pilotage Calculations. Just look at the other lines.

--- a/2025_tariffs/Antwerp/Prompts/pilotage_out
+++ b/2025_tariffs/Antwerp/Prompts/pilotage_out
@@ -1,9 +1,13 @@
-Data usage rule:
+Goal: Calculate the Antwerp pilotage-out fee using the block-size method with exact tariffs.
+Use injected variables first; consult the invoice only if a value is missing.
+Return a numbered, human-readable breakdown followed by a JSON summary.
 
+Data usage rule:
 Use provided variables first.
 Only if a variable is missing, try to parse it from the invoice text.
 If still missing, leave as “not provided”.
 Bunker Adjustment Factor (BAF) MUST be taken from the invoice and added to the final amount. If not found, use 0 and note the source as “not found in invoice”.
+
 Inputs (use or derive):
 
 length_m

--- a/2025_tariffs/Antwerp/Prompts/ship_movement
+++ b/2025_tariffs/Antwerp/Prompts/ship_movement
@@ -1,6 +1,12 @@
-Check vessel LOA and use below table to look up correct tariff.
+Antwerp Ship Movement (VBS)
+---------------------------
 
-LOA_Antwerp_TARIFFS = 
+Use injected inputs first; only consult the invoice if LOA or rounding is missing.
+Return a numbered, human-readable breakdown:
+1. LOA provided and LOA used (after rounding).
+2. Tariff looked up in the table below.
+
+LOA_Antwerp_TARIFFS =
 
 41,118
 42,118
@@ -218,4 +224,8 @@ LOA_Antwerp_TARIFFS =
 999,1318
 1000,1318
 
-On the invoice from pilotage this amount is mentioned as a separate line and is called VBS
+Output:
+- Tariff in EUR
+- Step-by-step explanation as above
+
+Note: on pilotage invoices this amount appears as a line named "VBS".

--- a/2025_tariffs/Antwerp/Prompts/unmooring
+++ b/2025_tariffs/Antwerp/Prompts/unmooring
@@ -1,60 +1,78 @@
-1) Base by LOA:
-   - Find the band where LOA_m ∈ [from, to] in UNMOORING_TARIFFS (see table).
-   - Base = that tariff.
-   - If LOA_m > 400:
-       extra_segments = ceil((LOA_m - 400) / 5)
-       Base += extra_segments × 109   # FRACTION_RATES["unmooring"] = 109
+Antwerp Unmooring Fee
+---------------------
 
-2) Time supplement (mutually exclusive):
-   - If Sunday (weekday = 6): TimeSuppl = Base × 0.50
-   - Else if hour ≥ 19 or < 7: TimeSuppl = Base × 0.25
-   - Else: TimeSuppl = 0
+Use injected values first; consult the invoice only if a value is missing, and note if still absent.
+Return a numbered, human-readable breakdown and the final amount. If a billed amount exists, show the variance and Pass/Fail at ±2%.
 
-3) Location supplement:
-   - If "riverquay" in Location (case-insensitive): LocSuppl = Base × 0.30
-   - Else: 0
-
-4) Delay supplement:
+Steps
+1. Base by LOA:
+   - Pick the row where LOA_m lies within [from, to] in UNMOORING_TARIFFS.
+   - If LOA_m > 400: extra_segments = ceil((LOA_m-400)/5);
+     Base += extra_segments × 109 (FRACTION_RATES["unmooring"]).
+2. Time supplement (choose one):
+   - Sunday → +50% of Base
+   - Night (19:00–07:00) → +25% of Base
+   - Otherwise 0
+3. Location supplement: +30% of Base if Location contains "riverquay".
+4. Delay supplement:
    - If DelayMinutes > 45:
-       HoursDelayed = ceil((DelayMinutes - 45)/60)
+       HoursDelayed = ceil((DelayMinutes-45)/60)
        DelaySuppl = (Base + TimeSuppl + LocSuppl) × 0.50 × HoursDelayed
-   - Else: 0
-
-5) Reductions:
-   - Reductions = 0
-   - If IsSecondCall: Reductions += Base × 0.25
-   - If IsShortMovement: Reductions += Base × 0.50
-
-6) Cancellation:
-   - CancelFee = Base × 0.50 if IsCancelled else 0
-
-7) Final amount:
-   - Total = Base + TimeSuppl + LocSuppl + DelaySuppl + CancelFee - Reductions
-   - FinalAmountEUR = round(Total, 2)
-
-8) Validation:
-   - Accept if |FinalAmountEUR - BilledAmountEUR| / FinalAmountEUR ≤ 0.02
-   - Else, fail with a brief reason (wrong LOA band, night/Sunday not applied, riverquay, delay, reductions, cancellation).
-
-CHECK THE INVOICE. THERE are certain things that we cannot capture without the invoice such as Extra Boatmen or Extra Motorboat. Those should directly be added from the invoice itself. If it is under Unmooring services, also add them to your final answer.
+   - Else 0
+5. Reductions: −25% of Base if IsSecondCall
+6. Cancellation fee: Base × 0.50 if IsCancelled else 0
+7. Total = Base + TimeSuppl + LocSuppl + DelaySuppl + CancelFee − Reductions
+8. Validate against invoice if provided.
 
 UNMOORING_TARIFFS (EUR):
 [
-  (0, 80.00, 113),(80.01, 90.00, 147),(90.01,100.00,151),(100.01,110.00,203),
-  (110.01,120.00,211),(120.01,130.00,241),(130.01,138.00,253),(138.01,146.00,268),
-  (146.01,152.00,300),(152.01,157.00,342),(157.01,160.00,353),(160.01,167.50,375),
-  (167.51,175.00,466),(175.01,182.50,513),(182.51,190.00,546),(190.01,197.50,570),
-  (197.51,205.00,609),(205.01,212.50,624),(212.51,220.00,668),(220.01,227.50,701),
-  (227.51,235.00,807),(235.01,242.50,899),(242.51,250.00,938),(250.01,257.50,968),
-  (257.51,265.00,1008),(265.01,272.50,1044),(272.51,280.00,1072),(280.01,287.50,1111),
-  (287.51,295.00,1188),(295.01,302.50,1369),(302.51,310.00,1434),(310.01,317.50,1585),
-  (317.51,325.00,1717),(325.01,330.00,1927),(330.01,335.00,2136),(335.01,340.00,2344),
-  (340.01,345.00,2446),(345.01,350.00,2542),(350.01,355.00,2563),(355.01,360.00,2682),
-  (360.01,365.00,2795),(365.01,370.00,2909),(370.01,375.00,3017),(375.01,380.00,3126),
-  (380.01,385.00,3235),(385.01,390.00,3341),(390.01,395.00,3450),(395.01,400.00,3559)
+    (0, 80.00, 126),
+    (80.01, 90.00, 151),
+    (90.01, 100.00, 156),
+    (100.01, 110.00, 210),
+    (110.01, 120.00, 217),
+    (120.01, 130.00, 247),
+    (130.01, 138.00, 259),
+    (138.01, 146.00, 276),
+    (146.01, 152.00, 310),
+    (152.01, 157.00, 355),
+    (157.01, 160.00, 365),
+    (160.01, 167.50, 388),
+    (167.51, 175.00, 480),
+    (175.01, 182.50, 529),
+    (182.51, 190.00, 563),
+    (190.01, 197.50, 589),
+    (197.51, 205.00, 622),
+    (205.01, 212.50, 637),
+    (212.51, 220.00, 683),
+    (220.01, 227.50, 717),
+    (227.51, 235.00, 825),
+    (235.01, 242.50, 920),
+    (242.51, 250.00, 960),
+    (250.01, 257.50, 991),
+    (257.51, 265.00, 1033),
+    (265.01, 272.50, 1072),
+    (272.51, 280.00, 1102),
+    (280.01, 287.50, 1139),
+    (287.51, 295.00, 1216),
+    (295.01, 302.50, 1402),
+    (302.51, 310.00, 1468),
+    (310.01, 317.50, 1604),
+    (317.51, 325.00, 1746),
+    (325.01, 330.00, 1960),
+    (330.01, 335.00, 2177),
+    (335.01, 340.00, 2393),
+    (340.01, 345.00, 2502),
+    (345.01, 350.00, 2586),
+    (350.01, 355.00, 2609),
+    (355.01, 360.00, 2722),
+    (360.01, 365.00, 2831),
+    (365.01, 370.00, 2940),
+    (370.01, 375.00, 3048),
+    (375.01, 380.00, 3157),
+    (380.01, 385.00, 3266),
+    (385.01, 390.00, 3373),
+    (390.01, 395.00, 3481),
+    (395.01, 400.00, 3588)
 ]
-
-Constants:
-- Night window: 19:00–07:00 → +25%
-- Sunday: +50% (overrides night)
-- FRACTION_RATES["unmooring"] = 109 EUR per 5m beyond 400m
+Fraction rate beyond 400m: 109 EUR per 5m.

--- a/2025_tariffs/Antwerp/Prompts/waste_Fees
+++ b/2025_tariffs/Antwerp/Prompts/waste_Fees
@@ -1,92 +1,30 @@
-You are to compute the Compulsory Waste Fee for Port of Antwerp using ONLY the variables provided below. Do not parse or rely on any invoice text. Do not apply any other surcharges/discounts beyond what is explicitly listed here.
+Antwerp Compulsory Waste Fee
+---------------------------
 
-CONSTANTS (set these before calculation; per current tariff-year):
-- FIXED_WASTE_FEE_EUR = <enter fixed fee, e.g., 150.00>
-- WASTE_TARIFF_PER_GT_EUR = <enter rate per GT, e.g., 0.0450>
-- SHORT_VOYAGE_DISCOUNT_RATE = 0.05  # 5%
+Use the constants and inputs injected in the prompt. Only check the invoice if any value is missing; if still absent, mark it as unknown.
+Return a numbered, human-readable breakdown and the final fee. Do not apply other surcharges or discounts.
 
-INPUTS (taken as-is from the message data):
-- Vessel particulars:
-  - Name: {{vessel.name}}
-  - GT (gross tonnage): {{vessel.particulars.grossTonnage}}
-  - Reduced GT: {{vessel.particulars.reducedGrossTonnage}}
-  - NT: {{vessel.particulars.netTonnage}}
-  - LOA: {{vessel.particulars.loa}}
-  - BOA: {{vessel.particulars.boa}}
-  - LBP: {{vessel.particulars.lbp}}
-  - Type: {{vessel.type}}
-  - ESI score: {{vessel.esiScore}}
-  - Green Award score: {{vessel.greenAward}}
+Constants
+- FIXED_WASTE_FEE_EUR = {{fixed_fee_eur}}
+- WASTE_TARIFF_PER_GT_EUR = {{tariff_per_gt_eur}}
+- SHORT_VOYAGE_DISCOUNT_RATE = 0.05
 
-- Port call data (not used unless to set flags):
-  - Draft in: {{portCall.prospects.currentProspects.arrival.details.draftAft}}
-  - Draft out: {{portCall.prospects.currentProspects.departureDraftAft}}
-  - Tugs in: {{portCall.prospects.currentProspects.arrival.details.tugs}}
-  - Tugs out: {{portCall.prospects.currentProspects.departure.details.tugs}}
-  - Cargo list and terminals provided but not used in the computation unless they explicitly set flags.
+Inputs
+- GT = {{vessel.particulars.grossTonnage}}
+- ISO14001Certified = {{vessel.iso14001}}
+- IsShortVoyage = {{voyage.shortVoyage}}
+- InvoiceAmountExclVAT (optional)
 
-FLAGS (set explicitly; default False if unknown):
-- is_iso_certified = <true/false>  # Only if an ISO 14001 certificate is explicitly confirmed
-- is_short_movement = <true/false> # Only if the waste tariff explicitly allows “short voyage/movement” discount for this call
+Steps
+1. VariableFee = GT × WASTE_TARIFF_PER_GT_EUR
+2. InitialFee = FIXED_WASTE_FEE_EUR + VariableFee
+3. ISO discount = 10% of InitialFee if ISO14001Certified
+4. Short-voyage discount = 5% of InitialFee if IsShortVoyage
+5. TotalFee = InitialFee − ISO discount − Short-voyage discount
+6. Round TotalFee to 2 decimals
+7. If invoice amount provided: variance = |TotalFee − Invoice| / TotalFee and flag Pass/Fail at ±2%
 
-INVOICE FIELDS (used only for ±2% comparison; do NOT influence computation):
-- line.currency = {{line.currency}}
-- line.localAmount = {{line.localAmount}}
-- line.line.name = {{line.line.name}}
-
-RULES:
-1) Use GT = {{vessel.particulars.grossTonnage}} as gt_size. Do NOT switch to Reduced GT or NT unless explicitly instructed; leave at GT.
-2) Compute:
-   - variable_fee = gt_size × WASTE_TARIFF_PER_GT_EUR
-   - initial_fee = FIXED_WASTE_FEE_EUR + variable_fee
-   - total_fee = initial_fee
-3) Discounts applied ONLY on initial_fee, in this order and only if flag is true:
-   a) ISO 14001 discount: 10% of initial_fee (if is_iso_certified = true)
-   b) Short Voyage discount: 5% of initial_fee (if is_short_movement = true)
-   Subtract each applicable discount from total_fee and list them in the breakdown.
-4) No other discounts/surcharges apply.
-
-OUTPUT:
-A) Human-readable breakdown (exact lines):
-- "Compulsory Waste Fee Calculation - Port of Antwerp"
-- "Fixed Fee: {FIXED_WASTE_FEE_EUR:.2f} EUR"
-- "Variable Fee: GT {gt_size} x {WASTE_TARIFF_PER_GT_EUR:.4f} = {variable_fee:.2f} EUR"
-- If is_iso_certified: "- ISO 14001 Certificate Discount Applied (10%): -{iso_discount:.2f} EUR"
-- If is_short_movement: "- Short Voyage Discount Applied (5%): -{short_discount:.2f} EUR"
-- "Total Waste Fee: {total_fee:.2f} EUR"
-
-B) JSON summary:
-{
-  "inputs": {
-    "gt_size": <number>,
-    "is_iso_certified": <bool>,
-    "is_short_movement": <bool>,
-    "fixed_waste_fee_eur": <number>,
-    "waste_tariff_per_gt_eur": <number>,
-    "short_voyage_discount_rate": 0.05,
-    "invoice_amount": {{line.localAmount}},
-    "currency": "{{line.currency}}",
-    "line_name": "{{line.line.name}}"
-  },
-  "calculation": {
-    "variable_fee_eur": <number>,
-    "initial_fee_eur": <number>,
-    "iso_discount_eur": <number or 0>,
-    "short_voyage_discount_eur": <number or 0>,
-    "total_fee_eur": <number>
-  },
-  "validation": {
-    "variance_pct": abs(total_fee_eur - invoice_amount) / total_fee_eur,
-    "pass_within_2pct": (abs(total_fee_eur - invoice_amount) / total_fee_eur) <= 0.02
-  },
-  "notes": [
-    "Computation is variables-only (no invoice parsing).",
-    "Discounts applied only if explicitly flagged."
-  ]
-}
-
-TASK:
-- Fill constants and flags.
-- Use gt_size = {{vessel.particulars.grossTonnage}}.
-- Produce the breakdown and JSON summary exactly as specified.
-- Do not add any other adjustments.
+Output
+- TotalFee in EUR
+- Numbered breakdown of each step
+- Invoice variance and Pass/Fail if invoice amount supplied


### PR DESCRIPTION
## Summary
- rewrite harbour dues prompt to prioritize injected constants and outline tariffs and discounts step-by-step
- simplify mooring and unmooring prompts with data usage rules and full LOA tables
- clarify pilotage, ship movement, and waste fee prompts to show numbered breakdowns and use invoice only when inputs are missing

## Testing
- `files=$(find 2025_tariffs/Antwerp -name '*.py'); if [ -n "$files" ]; then python -m py_compile $files; else echo 'No Python files to compile'; fi`


------
https://chatgpt.com/codex/tasks/task_e_68a82e08f1b8832eb34032ffcd1d3f42