### PR TITLE
Clarify prompt injections

### DIFF
--- a/2025_tariffs/Antwerp/Prompts/harbour_dues
+++ b/2025_tariffs/Antwerp/Prompts/harbour_dues
@@ -4,6 +4,22 @@ Antwerp Harbour Dues
 Use values provided through injected variables. Only read the invoice if a required value is missing; if still missing, report it.
 Return a numbered, human-readable breakdown and the final amount. If an invoice amount is available, show the variance and note Pass/Fail at ±2%.
 
+Inputs
+------
+- vessel_type = {{vessel_type_raw}}
+- gt = {{gt}}
+- voyage_number = {{voyage_number}}
+- is_shortsea = {{is_shortsea}}
+- is_liner = {{is_liner}}
+- esi_score = {{esi_score}}
+- vessel_built_year = {{vessel_built_year}}
+- special_rate = {{special_rate}}
+- days_in_port = {{days_in_port}}
+- loaded_tons = {{loaded_tons}}
+- discharged_tons = {{discharged_tons}}
+- unit_rate_eur_per_ton = {{unit_rate}}
+- invoice_amounts (optional)
+
 Products
 ========
 1. ZVR_GT – GT-based harbour dues

--- a/2025_tariffs/Antwerp/Prompts/mooring
+++ b/2025_tariffs/Antwerp/Prompts/mooring
@@ -4,6 +4,17 @@ Antwerp Mooring Fee
 Use injected variables first. Only consult the invoice when a value is missing; if still absent, state it.
 Return a numbered, human-readable breakdown and the final amount. If a billed amount is known, show the variance and mark Pass/Fail at ±2%.
 
+Inputs
+------
+- loa_m = {{loa_m}}
+- service_time = {{service_time}}
+- location = {{location}}
+- delay_minutes = {{delay_minutes}}
+- is_second_call = {{is_second_call}}
+- is_short_movement = {{is_short_movement}}
+- is_cancelled = {{is_cancelled}}
+- invoice_amount (optional)
+
 Steps
 1. Base tariff by LOA:
    - Find the row where LOA_m is between "from" and "to" in MOORING_TARIFFS.

--- a/2025_tariffs/Antwerp/Prompts/pilotage_in
+++ b/2025_tariffs/Antwerp/Prompts/pilotage_in
@@ -12,16 +12,16 @@ Data usage rule:
 -Bunker Adjustment Factor HAS TO BE taken from the invoice and added to the final amount. We cannot capture the bunker adjustment factor so please look at it from the invoice.
 
 Inputs (use or derive):
-- length_m
-- breadth_m
-- max_summer_draught_m
-- routes (list of strings; must match the exact route keys below)
-- baf_percentage (%, can be 0)
-- cancellation_fee (EUR)
-- delay_fee (EUR)
-- storm_pilot_fee (EUR)
-- special_case_fee (EUR)
-- custom_volume_discount (%, optional; if absent, use 0)
+- length_m = {{length_m}}
+- breadth_m = {{breadth_m}}
+- max_summer_draught_m = {{max_summer_draught_m}}
+- routes = {{routes}} (list of strings; must match the exact route keys below)
+- baf_percentage = {{baf_percentage}} (%, can be 0)
+- cancellation_fee = {{cancellation_fee}} (EUR)
+- delay_fee = {{delay_fee}} (EUR)
+- storm_pilot_fee = {{storm_pilot_fee}} (EUR)
+- special_case_fee = {{special_case_fee}} (EUR)
+- custom_volume_discount = {{custom_volume_discount}} (%, optional; if absent, use 0)
 
 Allowed route keys (must match exactly):
 - "Zee-omgekeerd"

--- a/2025_tariffs/Antwerp/Prompts/pilotage_out
+++ b/2025_tariffs/Antwerp/Prompts/pilotage_out
@@ -9,17 +9,16 @@ If still missing, leave as “not provided”.
 Bunker Adjustment Factor (BAF) MUST be taken from the invoice and added to the final amount. If not found, use 0 and note the source as “not found in invoice”.
 
 Inputs (use or derive):
-
-length_m
-breadth_m
-max_summer_draught_m (if invoice shows draught in dm, convert to meters)
-routes (list of strings; must match the exact route keys below)
-baf_percentage (%, can be 0; must come from invoice if present)
-cancellation_fee (EUR)
-delay_fee (EUR)
-storm_pilot_fee (EUR)
-special_case_fee (EUR)
-custom_volume_discount (%, optional; default 0 if absent)
+ - length_m = {{length_m}}
+ - breadth_m = {{breadth_m}}
+ - max_summer_draught_m = {{max_summer_draught_m}} (if invoice shows draught in dm, convert to meters)
+ - routes = {{routes}} (list of strings; must match the exact route keys below)
+ - baf_percentage = {{baf_percentage}} (%, can be 0; must come from invoice if present)
+ - cancellation_fee = {{cancellation_fee}} (EUR)
+ - delay_fee = {{delay_fee}} (EUR)
+ - storm_pilot_fee = {{storm_pilot_fee}} (EUR)
+ - special_case_fee = {{special_case_fee}} (EUR)
+ - custom_volume_discount = {{custom_volume_discount}} (%, optional; default 0 if absent)
 Allowed route keys (must match exactly):
 
 "Zee-omgekeerd"

--- a/2025_tariffs/Antwerp/Prompts/ship_movement
+++ b/2025_tariffs/Antwerp/Prompts/ship_movement
@@ -1,7 +1,7 @@
 Antwerp Ship Movement (VBS)
 ---------------------------
 
-Use injected inputs first; only consult the invoice if LOA or rounding is missing.
+Use the LOA: {{loa_m}} first; only consult the invoice if LOA or rounding is missing.
 Return a numbered, human-readable breakdown:
 1. LOA provided and LOA used (after rounding).
 2. Tariff looked up in the table below.

--- a/2025_tariffs/Antwerp/Prompts/unmooring
+++ b/2025_tariffs/Antwerp/Prompts/unmooring
@@ -4,6 +4,16 @@ Antwerp Unmooring Fee
 Use injected values first; consult the invoice only if a value is missing, and note if still absent.
 Return a numbered, human-readable breakdown and the final amount. If a billed amount exists, show the variance and Pass/Fail at ±2%.
 
+Inputs
+------
+- loa_m = {{loa_m}}
+- service_time = {{service_time}}
+- location = {{location}}
+- delay_minutes = {{delay_minutes}}
+- is_second_call = {{is_second_call}}
+- is_cancelled = {{is_cancelled}}
+- invoice_amount (optional)
+
 Steps
 1. Base by LOA:
    - Pick the row where LOA_m lies within [from, to] in UNMOORING_TARIFFS.


### PR DESCRIPTION
## Summary
- Specify injected variables for each Antwerp tariff prompt
- Inline LOA injection for ship movement prompt
- Ensure pilotage prompts list only required inputs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a83ee75b54832eb1e47701b6f43a9f